### PR TITLE
Added support for gnupg2 from macports.

### DIFF
--- a/pwd.sh
+++ b/pwd.sh
@@ -7,6 +7,10 @@ set -o nounset
 set -o pipefail
 
 gpg=$(which gpg)
+if [ $? -eq 1 ]; then
+  # gpg not found, try to search gpg2
+  gpg=$(which gpg2)
+fi
 safe=${PWDSH_SAFE:=pwd.sh.safe}
 
 


### PR DESCRIPTION
Just macports uses gpg2 for gnupg cmd:
```
sudo port install gnupg2
```
```
$ which gpg; echo $?
1
$ which gpg2; echo $?
/opt/local/bin/gpg2
0
```