### PR TITLE
added ability to copy password to clipboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Type `w` to write a password.
 
 Type `r` to read a password(s).
 
+Type `c` to copy a password to the clipboard (mac only).
+
 Type `d` to delete a password.
 
 Options can also be passed on the command line. Here are some examples:

--- a/pwd.sh
+++ b/pwd.sh
@@ -89,6 +89,11 @@ read_pass () {
   decrypt ${password} ${safe} | grep " ${username}" || fail "Decryption failed"
 }
 
+copy_pass () {
+  read_pass"$@" | cut -d ' ' -f1 | pbcopy
+  printf "\nPassword copied to clipboard"
+}
+
 
 gen_pass () {
   # Generate a password.
@@ -185,7 +190,7 @@ sanity_check
 
 if [[ -z "${1+x}" ]] ; then
   read -n 1 -p "
-  Read, write, or delete password? (r/w/d, default: r) " action
+  Read, copy, write, or delete password? (r/c/w/d, default: r) " action
   printf "\n"
 else
   action="${1}"
@@ -203,6 +208,9 @@ elif [[ "${action}" =~ ^([dD])$ ]] ; then
     username="${2}"
   fi
   write_pass
+
+elif [[ "${action}" =~ ^([cC])$ ]] ; then
+  copy_pass "$@"
 
 else
   read_pass "$@"


### PR DESCRIPTION
- adds "c" option, which will copy passward to clipboard on mac only (using `pbcopy`)
- this is probably a security risk... is there a way to clear the clipboard contents after a specified time?