### PR TITLE
Allow shell specia chars in username

### DIFF
--- a/pwd.sh
+++ b/pwd.sh
@@ -74,7 +74,7 @@ read_pass () {
   fi
 
   if [[ -z "${2+x}" ]] ; then
-    read -p "
+    read -r -p "
   Username to read? (default: all) " username
   else
     username="${2}"
@@ -146,7 +146,7 @@ create_username () {
   # Create username with password.
 
   if [[ -z "${2+x}" ]] ; then
-    read -p "
+    read -r -p "
   Username: " username
   else
     username="${2}"

--- a/pwd.sh
+++ b/pwd.sh
@@ -87,7 +87,7 @@ read_pass () {
   get_pass "
   Enter password to unlock ${safe}: "
   printf "\n\n"
-  decrypt ${password} ${safe} | grep " ${username}" || fail "Decryption failed"
+  decrypt ${password} ${safe} | grep -F " ${username}" || fail "Decryption failed"
 }
 
 


### PR DESCRIPTION
 Don't evaluate \ when reading username
    
This allows entering Microsoft Domain users like DOMAIN\USER.